### PR TITLE
Fix environment variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ After building the image, execute it with docker run.
     Default value is the localhost 127.0.0.1.
     - BUTTON_EVENTS_PORT: the port where the button events will be published.
     Default value is 5556.
-    - SHUTDOWN_HOST: the host where the shutdown message will be sent.
+    - SHUTDOWN_SERVICE_HOST: the host where the shutdown message will be sent.
     Default value is "127.0.0.1"
-    - SHUTDOWN_PORT: the port where the shutdown message will be sent.
+    - SHUTDOWN_SERVICE_PORT: the port where the shutdown message will be sent.
     Default value is 5558
 
 ## Author

--- a/src/main.py
+++ b/src/main.py
@@ -12,8 +12,8 @@ SHUTDOWN_EVENT = os.environ.get("SHUTDOWN_EVENT", "long_click")
 LOG_LEVEL = os.environ.get("LOG_LEVEL", logging.INFO)
 BUTTON_EVENTS_PORT = int(os.environ.get("BUTTON_EVENTS_PORT", 5556))
 BUTTON_EVENTS_HOST = os.environ.get("BUTTON_EVENTS_HOST", "127.0.0.1")
-SHUTDOWN_SERVICE_HOST = os.environ.get("SHUTDOWN_HOST", "127.0.0.1")
-SHUTDOWN_SERVICE_PORT = int(os.environ.get("SHUTDOWN_PORT", 5558))
+SHUTDOWN_SERVICE_HOST = os.environ.get("SHUTDOWN_SERVICE_HOST", "127.0.0.1")
+SHUTDOWN_SERVICE_PORT = int(os.environ.get("SHUTDOWN_SERVICE_PORT", 5558))
 
 SHUTDOWN_COMMAND = "shutdown"
 


### PR DESCRIPTION
The name of the variable was the new one, but the name in os.environ.get() was the old name.

When merging this pull request a new tag will need to be created.